### PR TITLE
Fix nostrum-use for non-elite

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = function Essentials(dispatch) {
 	function nostrum() {
 		clearTimeout(timeoutNostrum)
 		
-		if(game.isIngame && game.me.alive && !game.isInLoadingScreen && !game.me.mounted && !game.contract.active && !game.me.inBattleground && slot && !iAmInvincible)
+		if(game.isIngame && game.me.alive && !game.isInLoadingScreen && !game.me.mounted && !game.contract.active && !game.me.inBattleground && (slot || !ELITE) && !iAmInvincible)
 			timeoutNostrum = setTimeout(useNostrum, nextUse - Date.now())
 	}
 


### PR DESCRIPTION
For non-elite / non-club tera user the prime battle solution has never been used. Now, fixed by replacing "`slot`" with "`(slot || !ELITE)`" inside `function nostrum()`. "`slot`" was always false when you got no elite status, because you got no elite bar and that's why `useNostrum()` was never used as non-elite.
Now, it checks for `slot` only if `ELITE` is also true. Otherwise slot checking is skipped.